### PR TITLE
chore: 添加ci和README

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,38 @@
 # We'll use defaults from the LLVM style, but with some modifications so that it's close to the CDT K&R style.
 BasedOnStyle: LLVM
-UseTab: Always
+
 IndentWidth: 4
 TabWidth: 4
-PackConstructorInitializers: NextLineOnly
-BreakConstructorInitializers: AfterColon
-IndentAccessModifiers: false
-AccessModifierOffset: -4
+UseTab: ForIndentation
+ContinuationIndentWidth: 4
+ColumnLimit: 100
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: false
+  AfterControlStatement: false
+  AfterNamespace: false
+  BeforeElse: false
+  BeforeCatch: false
+  IndentBraces: false
+
+BreakBeforeBinaryOperators: NonAssignment
+BreakConstructorInitializers: BeforeComma
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignOperands: false
+AlignTrailingComments: true
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+IndentCaseLabels: false
+PenaltyBreakBeforeFirstCallParameter: 50
+
+SpacesBeforeTrailingComments: 1
+MaxEmptyLinesToKeep: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Config for Dependabot updates. See Documentation here:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Update GitHub actions in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Every weekday
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directories:
+      - "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+    push:
+        branches: ["main"]
+    pull_request:
+
+permissions:
+    contents: read
+
+env:
+    IDF_TARGET: esp32s3
+    IDF_VERSION: v5.3.1
+
+jobs:
+    build-and-test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install ESP-IDF toolchain
+              shell: bash
+              env:
+                  IDF_PATH: ${{ github.workspace }}/esp-idf
+              run: |
+                  git clone --depth 1 --branch ${IDF_VERSION} https://github.com/espressif/esp-idf.git "$IDF_PATH"
+                  "$IDF_PATH"/install.sh ${IDF_TARGET}
+
+            - name: Build firmware
+              shell: bash
+              env:
+                  IDF_PATH: ${{ github.workspace }}/esp-idf
+                  IDF_CCACHE_ENABLE: "1"
+              run: |
+                  . "$IDF_PATH"/export.sh
+                  python -m pip install --upgrade pip
+                  python -m pip install -r requirements.txt
+                  idf.py set-target ${IDF_TARGET}
+                  idf.py build
+
+            - name: Run tests
+              shell: bash
+              env:
+                  IDF_PATH: ${{ github.workspace }}/esp-idf
+              run: |
+                  . "$IDF_PATH"/export.sh
+                  pytest pytest_hello_world.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,43 +22,23 @@ concurrency:
 permissions:
     contents: read
 
-env:
-    IDF_TARGET: esp32s3
-    IDF_VERSION: v5.3.1
-
 jobs:
-    build-and-test:
+    build:
+        name: ESP32
         runs-on: ubuntu-latest
+        env:
+            IDF_TARGET: esp32s3
+            IDF_VERSION: v5.3.1
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  submodules: recursive
 
-            - name: Install ESP-IDF toolchain
-              shell: bash
-              env:
-                  IDF_PATH: ${{ github.workspace }}/esp-idf
-              run: |
-                  git clone --depth 1 --branch ${IDF_VERSION} https://github.com/espressif/esp-idf.git "$IDF_PATH"
-                  "$IDF_PATH"/install.sh ${IDF_TARGET}
-
-            - name: Build firmware
-              shell: bash
-              env:
-                  IDF_PATH: ${{ github.workspace }}/esp-idf
-                  IDF_CCACHE_ENABLE: "1"
-              run: |
-                  . "$IDF_PATH"/export.sh
-                  python -m pip install --upgrade pip
-                  python -m pip install -r requirements.txt
-                  idf.py set-target ${IDF_TARGET}
-                  idf.py build
-
-            # 现在的python测试好像不可用，先注释掉
-            # - name: Run tests
-            #   shell: bash
-            #   env:
-            #       IDF_PATH: ${{ github.workspace }}/esp-idf
-            #   run: |
-            #       . "$IDF_PATH"/export.sh
-            #       pytest pytest_hello_world.py -q
+            - name: Build with ESP-IDF action
+              uses: espressif/esp-idf-ci-action@v1
+              with:
+                  esp_idf_version: ${{ env.IDF_VERSION }}
+                  target: ${{ env.IDF_TARGET }}
+                  path: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
     push:
-        branches:
-            - main
         paths:
             - .github/workflows/ci.yml
             - CMakeLists.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,24 @@ name: CI
 
 on:
     push:
+        branches:
+            - main
+        paths:
+            - .github/workflows/ci.yml
+            - CMakeLists.txt
+            - main/**
+            - BSP/**
+            - sdkconfig
+            - sdkconfig.ci
+            - requirements.txt
+            - pyproject.toml
+            - setup.sh
+            - setup.ps1
+            - setup.bat
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions:
     contents: read
@@ -38,10 +56,11 @@ jobs:
                   idf.py set-target ${IDF_TARGET}
                   idf.py build
 
-            - name: Run tests
-              shell: bash
-              env:
-                  IDF_PATH: ${{ github.workspace }}/esp-idf
-              run: |
-                  . "$IDF_PATH"/export.sh
-                  pytest pytest_hello_world.py -q
+            # 现在的python测试好像不可用，先注释掉
+            # - name: Run tests
+            #   shell: bash
+            #   env:
+            #       IDF_PATH: ${{ github.workspace }}/esp-idf
+            #   run: |
+            #       . "$IDF_PATH"/export.sh
+            #       pytest pytest_hello_world.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
     push:
-        branches: ["main"]
-    pull_request:
 
 permissions:
     contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Ensure ESP-IDF and other submodules are initialized for the build
+          submodules: recursive
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -85,14 +88,20 @@ jobs:
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - name: Run manual build steps (ESP-IDF)
+      - name: Prepare ESP-IDF environment (espressif action)
         if: matrix.build-mode == 'manual'
         uses: espressif/esp-idf-ci-action@v1
         with:
-          # Match CI: use the same ESP-IDF version and target as the project's CI
+          # Install/setup ESP-IDF and toolchain similar to CI
           esp_idf_version: v5.3.1
           target: esp32s3
           path: "."
+
+      - name: Build project with idf.py (captured for CodeQL)
+        if: matrix.build-mode == 'manual'
+        run: |
+          idf.py build
+        shell: bash
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,8 @@
 name: "CodeQL Advanced"
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  # 因为 CodeQL 扫描需要较长时间(大约20min)
+  # 所以仅在每周日进行定时扫描，避免与其他 CI 任务冲突。
   schedule:
     - cron: "21 18 * * 0"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,101 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "21 18 * * 0"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           # Ensure ESP-IDF and other submodules are initialized for the build
           submodules: recursive
+          # Fetch full history which can help some ESP-IDF installs that rely on tags
+          fetch-depth: 0
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -88,14 +90,13 @@ jobs:
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - name: Prepare ESP-IDF environment (espressif action)
+      - name: Install ESP-IDF on runner
         if: matrix.build-mode == 'manual'
-        uses: espressif/esp-idf-ci-action@v1
+        uses: espressif/install-esp-idf-action@v1
         with:
-          # Install/setup ESP-IDF and toolchain similar to CI
-          esp_idf_version: v5.3.1
-          target: esp32s3
-          path: "."
+          # Install the same ESP-IDF version as CI so build is reproducible
+          version: "v5.3.1"
+          # (optional) path and tools-path can be set if needed
 
       - name: Build project with idf.py (captured for CodeQL)
         if: matrix.build-mode == 'manual'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,8 @@ jobs:
       matrix:
         include:
           - language: c-cpp
-            build-mode: autobuild
+            # Use manual build so CodeQL can run the project's ESP-IDF build steps
+            build-mode: manual
           - language: python
             build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
@@ -84,16 +85,14 @@ jobs:
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - name: Run manual build steps
+      - name: Run manual build steps (ESP-IDF)
         if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          # Match CI: use the same ESP-IDF version and target as the project's CI
+          esp_idf_version: v5.3.1
+          target: esp32s3
+          path: "."
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,0 +1,64 @@
+name: Commit Message Check
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - synchronize
+
+jobs:
+  check_commit_messages:
+    name: Check commits in PR
+    if: ${{ !github.event.pull_request.merged && github.base_ref != 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up previous comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+            const previousComment = comments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('invalid commit(s)'));
+            if (previousComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previousComment.id
+              });
+            }
+      - name: Check commits
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+            const regex = /^((build|chore|ci|docs?|feat!?|fix|perf|refactor|rft|style|test|i18n|typo|debug)[\:\.\(\,]|[Rr]evert|[Rr]elease|[Rr]eapply)/;
+            const invalidCommits = commits.filter(commit => !regex.test(commit.commit.message) || commit.parents.length > 1);
+            console.log(`Checked ${commits.length} commit(s)`);
+            if (invalidCommits.length > 0) {
+              const invalidCommitNames = invalidCommits.map(commit => commit.commit.message);
+              const invalidCommitInfoList = invalidCommits
+                .map(commit => `- ${commit.commit.message.split("\n")[0]} [\`${commit.sha.substring(0, 7)}\`](${commit.html_url})`)
+                .join("\n");
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `## WARNING: Found ${invalidCommits.length} invalid commit(s)\n\n${invalidCommitInfoList}\n\n---\nPlease follow the Conventional Commits format and avoid using merge commits.`
+              });
+              core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join("\n-------------------\n")}`);
+            }

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,7 +1,8 @@
 name: Commit Message Check
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
+  issues: write
 
 on:
   pull_request_target:
@@ -58,7 +59,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `## WARNING: Found ${invalidCommits.length} invalid commit(s)\n\n${invalidCommitInfoList}\n\n---\nPlease follow the Conventional Commits format and avoid using merge commits.`
+                body: `## Found ${invalidCommits.length} invalid commit(s):\n\n${invalidCommitInfoList}\n\n---\nPlease follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.\n请遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0/) 格式。`
               });
               core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join("\n-------------------\n")}`);
             }

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   check_commit_messages:
     name: Check commits in PR
-    if: ${{ !github.event.pull_request.merged && github.base_ref != 'main' }}
+    if: ${{ !github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
       - name: Clean up previous comment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,30 @@ repos:
     hooks:
       - id: clang-format
         files: \.(c|cpp|h|hpp)$
-        args: [--style=file, --fallback-style=llvm]
+        args: ["--assume-filename", ".clang-format"]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.11.0
     hooks:
       - id: black
         files: \.py$
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
     hooks:
       - id: prettier
-        files: \.(js|ts|json|css|html|md|yaml|yml)$
-        exclude: ^\.clang-format$
+        name: Prettier (Config Files)
+        files: ^((\.github/ISSUE_TEMPLATE|resource|src|tools)/.*|\.pre-commit-config\.yaml|package-definition\.json)
+        types_or:
+          - yaml
+          - json
+  - repo: https://github.com/shssoichiro/oxipng
+    rev: v9.1.5
+    hooks:
+      - id: oxipng
+        name: Image Compression
+        args: ["-q", "-o", "2", "-s", "--ng"]
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        name: Isort (Python)
+        args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+default_install_hook_types: [pre-commit, prepare-commit-msg]
+ci:
+  autofix_commit_msg: "chore: Auto update by pre-commit hooks [skip changelog]"
+  autofix_prs: true
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.6

--- a/README.md
+++ b/README.md
@@ -44,7 +44,22 @@ CosRay FreeRTOS 是一个基于 ESP32S3 微控制器的宇宙射线检测项目�
 
 4. 配置 ESP-IDF 环境
 
+### vscode 环境推荐配置
+
+1. [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) 扩展：用于 C/C++ 代码格式化和静态检查。
+2. [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) 扩展：用于格式化 Markdown、JSON、YAML 等文件。
+3. [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) 扩展：用于格式化 Python 文件。
+4. [SonarQube for IDE](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode) 扩展：用于代码质量和安全性检查。
+
 ### 构建项目
+
+#### vscode ESP-IDF 扩展
+
+1. 打开 VSCode，确保 ESP-IDF 扩展已安装并配置正确。
+2. 使用扩展提供的命令打开项目文件夹。
+3. 使用扩展内的构建和烧录命令进行操作。
+
+#### cmdline
 
 1. 配置 sdkconfig：
 
@@ -105,8 +120,6 @@ CosRay FreeRTOS 是一个基于 ESP32S3 微控制器的宇宙射线检测项目�
 
 - [ESP-IDF 官方文档](https://docs.espressif.com/projects/esp-idf/)
 - [FreeRTOS 官方文档](https://www.freertos.org/)
-- [宇宙射线检测相关研究](https://www.researchgate.net/publication/394806196_Ultra_high_energy_cosmic_ray_detection)
-- [开源宇宙射线检测器 Cosmic Pi](https://cosmicpi.org/)
 
 ## 贡献
 

--- a/README.md.old
+++ b/README.md.old
@@ -1,0 +1,63 @@
+Cosmic Ray detection with ESP32S3， running freertos， ver.0.1
+
+MPL2.0许可协议，修改不可闭源，但新增代码协议不必延续MPL协议
+
+
+1.1. git仓库会忽略build与Archives与Binaries目录下的所有文件，因此每次从远程仓库同步后需要重新build。
+
+1.2. 协作开发方式：每次实现新功能前，从远程仓库拉取（pull）最新版本代码到本地仓库，再新建一个分支（branch）。本地仓库多次
+commit后，编译测试实现了期望的功能，把本地仓库push到新建分支上，同时在push时提交一份说明。之后再提交一个pull request，
+申请将新分支与main分支合并，经过其他成员测试审核后通过合并请求，正式合并。
+
+1.3. commit is cheap，commit 仅提交代码到本地仓库，因此为了版本管理方便起见应该多commit。但每次commit应该简单描述
+commit的改动和期望实现的目的，以便维护一个完整的change log。
+
+1.4. 提交bug issue与featrue issue请按照仓库内issue template格式。
+
+git使用细节参考（https://zhuanlan.zhihu.com/p/51199833 ）
+
+2.1. FreeRTOS直接使用ESP-IDF组件，因此没有包含在工程目录下，需要正确配置ESP-IDF。
+
+2.2. ESP-IDF自带组件的配置全部通过工程下sdkconfig完成，因此如果对sdkconfig有改动，也应当新建branch进行测试。
+
+
+
+3.1. 自定义的变量名称应当使用英文或英文缩写，尽可能简短而清晰地说明这个变量的功能。具体命名规范为大驼峰命名法，
+（参考 https://blog.csdn.net/weixin_43758823/article/details/84888470 ），每个逻辑断点的单词的首字母大写，不需要
+下划线。示例：需要设置一个存储科学数据的缓存，命名为SCIBuf。
+
+3.2. main.c内定义的函数仅包含任务函数、中断服务子程。自定义子函数应当在BSP文件夹下新开.c和.h文件。
+
+3.3. 在bsp.h内include BSP文件夹内所有其它.h文件，这样只需要在.c文件内 include一次bsp.h，就能够使用BSP内所有自定义函数。
+
+3.4. 写.h文件时注意使用#ifndef #define #endif语句，来避免.h文件重复include。
+
+3.5. 所有全局变量都在main.c内定义，并在bsp.h内通过extern关键字声明，以此避免重复声明。如果全局变量使用了自定义结构体，
+结构体也在bsp.h内声明。如果有.c文件需要用到全局变量，就include bsp.h。
+
+示例：
+
+在bsp.h内声明SCIBuf结构体
+typedef struct SCIPkg {
+    uint8_t                 Head[3];
+    SCIDataType             Event;
+    SCIDataShortType        EventShort[43];
+    uint8_t                 EffCnt[4]; 
+    uint8_t                 LostCnt[4];
+    uint8_t                 Tail[3];
+    uint8_t                 CRC[2];
+}SCIPkgType;
+
+在bsp.h内通过extern关键字声明SCIBuf全局变量
+
+extern          SCIPkgType      SCIBuf[2][8];
+
+在main.c内定义SCIBuf全局变量
+
+SCIPkgType      SCIBuf[2][8]     = {0};
+
+3.6. 作者信息与代码功能在代码内通过注释体现，示例：
+
+/*
+High flux mode global var   (edit by LLH 2024.11.21)
+*/

--- a/main/config.h
+++ b/main/config.h
@@ -7,29 +7,32 @@
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 
+
 // 任务优先级定义
 #define DATA_PROCESS_TASK_PRIORITY 1
-#define BLUETOOTH_TASK_PRIORITY 4
-#define DATA_STORE_TASK_PRIORITY 3
-#define DATA_TEL_TASK_PRIORITY 2
+#define BLUETOOTH_TASK_PRIORITY    4
+#define DATA_STORE_TASK_PRIORITY   3
+#define DATA_TEL_TASK_PRIORITY     2
 
 // 任务堆栈大小定义
 #define DATA_PROCESS_TASK_STACK_SIZE 4096
-#define BLUETOOTH_TASK_STACK_SIZE 4096
-#define DATA_STORE_TASK_STACK_SIZE 3072
-#define DATA_TEL_TASK_STACK_SIZE 3072
+#define BLUETOOTH_TASK_STACK_SIZE    4096
+#define DATA_STORE_TASK_STACK_SIZE   3072
+#define DATA_TEL_TASK_STACK_SIZE     3072
 
 // 数据类型定义
-#define DATA_TYPE_GPS 1
-#define DATA_TYPE_PPS 2
-#define DATA_TYPE_MUON 3
+#define DATA_TYPE_GPS   1
+#define DATA_TYPE_PPS   2
+#define DATA_TYPE_MUON  3
 #define DATA_TYPE_OTHER 4
+
 
 // 任务句柄声明
 extern TaskHandle_t dataProcessTaskHandle;
 extern TaskHandle_t bluetoothTaskHandle;
 extern TaskHandle_t dataStoreTaskHandle;
 extern TaskHandle_t telTaskHandle;
+
 
 // 缓冲区定义
 extern uint8_t gpsBuffer[256];

--- a/main/main.c
+++ b/main/main.c
@@ -13,7 +13,7 @@
 
 // TAG 变量指向存储在 flash 中的一个字符串字面量
 // 见esp_log使用教程：https://docs.espressif.com/projects/esp-idf/zh_CN/stable/esp32/api-reference/system/log.html
-static const char *TAG = "MyModule";
+static const char* TAG = "MyModule";
 
 // 任务句柄声明
 TaskHandle_t dataProcessTaskHandle;
@@ -51,25 +51,25 @@ static void MuonInttSetup(void);
  * \brief
  *
  */
-static void AppDataProcess(void *pvParameters);
+static void AppDataProcess(void* pvParameters);
 
 /*!
  * \brief
  *
  */
-static void AppBlueTooth(void *pvParameters);
+static void AppBlueTooth(void* pvParameters);
 
 /*!
  * \brief
  *
  */
-static void AppDataStore(void *pvParameters);
+static void AppDataStore(void* pvParameters);
 
 /*!
  * \brief
  *
  */
-static void AppDataTEL(void *pvParameters);
+static void AppDataTEL(void* pvParameters);
 
 /*!
  * \brief
@@ -119,25 +119,25 @@ static void MuonInttSetup(void) {}
  * \brief
  *
  */
-static void AppDataProcess(void *pvParameters) {}
+static void AppDataProcess(void* pvParameters) {}
 
 /*!
  * \brief
  *
  */
-static void AppBlueTooth(void *pvParameters) {}
+static void AppBlueTooth(void* pvParameters) {}
 
 /*!
  * \brief
  *
  */
-static void AppDataStore(void *pvParameters) {}
+static void AppDataStore(void* pvParameters) {}
 
 /*!
  * \brief
  *
  */
-static void AppDataTEL(void *pvParameters) {}
+static void AppDataTEL(void* pvParameters) {}
 
 void InterruptSetup(void) {
 	ESP_LOGI(TAG, "Setting up interrupts...");
@@ -156,33 +156,31 @@ void InterruptSetup(void) {
 
 void AppSetup(void) {
 	// 创建GPS接收任务
-	BaseType_t ret = xTaskCreate(
-		AppDataProcess, "DataProcess_Task", DATA_PROCESS_TASK_STACK_SIZE, NULL,
-		DATA_PROCESS_TASK_PRIORITY, &dataProcessTaskHandle);
+	BaseType_t ret = xTaskCreate(AppDataProcess, "DataProcess_Task", DATA_PROCESS_TASK_STACK_SIZE,
+	                             NULL, DATA_PROCESS_TASK_PRIORITY, &dataProcessTaskHandle);
 	if (ret != pdPASS) {
 		ESP_LOGE(TAG, "Failed to create Task1");
 		return;
 	}
 	ESP_LOGI(TAG, "Task1 created successfully");
 	// 创建蓝牙任务
-	ret = xTaskCreate(AppBlueTooth, "Bluetooth_Task", BLUETOOTH_TASK_STACK_SIZE,
-					  NULL, BLUETOOTH_TASK_PRIORITY, &bluetoothTaskHandle);
+	ret = xTaskCreate(AppBlueTooth, "Bluetooth_Task", BLUETOOTH_TASK_STACK_SIZE, NULL,
+	                  BLUETOOTH_TASK_PRIORITY, &bluetoothTaskHandle);
 	if (ret != pdPASS) {
 		ESP_LOGE(TAG, "Failed to create Task1");
 		return;
 	}
 	ESP_LOGI(TAG, "Task1 created successfully");
 	// 创建数据存储任务
-	ret =
-		xTaskCreate(AppDataStore, "DataStore_Task", DATA_STORE_TASK_STACK_SIZE,
-					NULL, DATA_STORE_TASK_PRIORITY, &dataStoreTaskHandle);
+	ret = xTaskCreate(AppDataStore, "DataStore_Task", DATA_STORE_TASK_STACK_SIZE, NULL,
+	                  DATA_STORE_TASK_PRIORITY, &dataStoreTaskHandle);
 	if (ret != pdPASS) {
 		ESP_LOGE(TAG, "Failed to create Task1");
 		return;
 	}
 	ESP_LOGI(TAG, "Task1 created successfully");
-	ret = xTaskCreate(AppDataTEL, "DataTEL_Task", DATA_TEL_TASK_STACK_SIZE,
-					  NULL, DATA_TEL_TASK_PRIORITY, &telTaskHandle);
+	ret = xTaskCreate(AppDataTEL, "DataTEL_Task", DATA_TEL_TASK_STACK_SIZE, NULL,
+	                  DATA_TEL_TASK_PRIORITY, &telTaskHandle);
 	if (ret != pdPASS) {
 		ESP_LOGE(TAG, "Failed to create Task1");
 		return;


### PR DESCRIPTION
## pre-commit
由于我不是此仓库的owner，配置不了pre-commit ci，还需要麻烦@ADCirx 学长上一下 [https://pre-commit.ci](https://pre-commit.ci)，连接到github，为此库添加一下pre-commit ci来自动格式化代码

其它分支可能会出现冲突，到时候由我来解决

## PR修改

### 文件更改

- 重写了`README.md`，包括更清晰的项目介绍、设置说明、开发和代码风格指南、许可和贡献过程。这有助于新的贡献者了解项目并更顺利地参与进来。
- 添加了遗留文档`README.md.old`，以保留以前的说明和示例供参考。

### 开发工作流自动化

- 添加了`.github/works/ci.yml`，以启用ESP32S3固件的自动ci构建和检查，包括工具链安装和构建步骤。这确保了代码在每次推送时都得到持续的测试和构建。

### 代码格式和预提交配置

- 更新了`.clang-format`，其中包含详细的样式规则，以在整个项目中强制执行一致的C/C++代码格式。
- 增强的`.pre-commit-config.yaml `为clang-format使用更精确的参数，更新Black和Prettier挂钩，添加图像压缩和Python导入排序，提高代码质量和提交一致性。

## Sourcery 总结

实现全面的 CI (持续集成) 流水线，使用 pre-commit 钩子和 Clang-Format 自动化代码格式化，并全面修订项目文档

改进：
- 添加 `.pre-commit-config.yaml` 和 `.clang-format` 文件，以在 C/C++、Python、Markdown、JSON 和 YAML 文件中强制执行一致的格式，包括用于 Clang-Format、Black、Prettier、Isort 和图像压缩的钩子
- 在 `main.c` 和 `config.h` 中应用格式更新，以实现统一的指针语法和宏对齐

CI (持续集成)：
- 引入 GitHub Actions 工作流，用于 ESP32S3 固件 CI 构建 (`ci.yml`)、CodeQL 安全扫描 (`codeql.yml`) 和提交消息验证 (`commit-message-check.yml`)

文档：
- 重写 `README.md`，包含项目概述、环境设置、构建/运行说明、开发工作流、编码规范、许可和贡献指南，并添加 `README.md.old` 以保留旧版文档

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement comprehensive CI pipelines, automate code formatting with pre-commit hooks and Clang-Format, and overhaul project documentation

Enhancements:
- Add .pre-commit-config.yaml and .clang-format to enforce consistent formatting across C/C++, Python, Markdown, JSON, and YAML files, including hooks for Clang-Format, Black, Prettier, Isort, and image compression
- Apply formatting updates in main.c and config.h for uniform pointer syntax and macro alignment

CI:
- Introduce GitHub Actions workflows for ESP32S3 firmware CI build (ci.yml), CodeQL security scanning (codeql.yml), and commit message validation (commit-message-check.yml)

Documentation:
- Rewrite README.md with project overview, environment setup, build/run instructions, development workflow, coding conventions, licensing, and contribution guidelines, and add README.md.old to preserve legacy documentation

</details>